### PR TITLE
Add max-idle configuration to dpu config

### DIFF
--- a/playbooks/dpu/README.md
+++ b/playbooks/dpu/README.md
@@ -44,6 +44,7 @@ In the `[dpu:vars]` section, assign the following variables:
 - ovs_timeout: ovs add port timeout
 - ovs_datapath_type: bridges datapath types (default: netdev)
 - mtu: uplink mtu
+- ovs_max_idle: determines the maximum time (in milliseconds) that idle flows will remain cached in the datapath before they are expired
 - hugepages_count: number of 2 MB huge pages
 - ovn_sb_db_ip: ovn south bound database ip ( control plane host ip ) that will be used to connect ovn controller with ovn south bound
 - ovn_bridge_mappings: maps a physical network name (physnet) to a specific OVS bridge

--- a/playbooks/dpu/inventory
+++ b/playbooks/dpu/inventory
@@ -47,6 +47,7 @@ bridge_name=br{{uplink_name}}
 ovs_timeout=30
 ovs_datapath_type=netdev
 mtu=9216
+ovs_max_idle=10000 #in milliseconds
 
 hugepages_count=1536
 

--- a/playbooks/dpu/tasks/dpu/configure_ovs.yaml
+++ b/playbooks/dpu/tasks/dpu/configure_ovs.yaml
@@ -49,6 +49,7 @@
       - { key: "dpdk-init", value: "true" }
       - { key: "doca-init", value: "true" }
       - { key: "hw-offload", value: "true" }
+      - { key: "max-idle", value: "{{ovs_max_idle}}" }
     ports_list:
       - { bridge: "{{bridge_name}}",  port: "{{uplink_name}}",  extra: "{{uplink_pci.stdout}},dv_xmeta_en=4,dv_flow_en=2" }
 

--- a/playbooks/system/inventory
+++ b/playbooks/system/inventory
@@ -57,6 +57,7 @@ bridge_name=br{{uplink_name}}
 ovs_timeout=30
 ovs_datapath_type=netdev
 mtu=9216
+ovs_max_idle=10000 #in milliseconds
 
 hugepages_count=1536
 


### PR DESCRIPTION
ovs_max_idle: determines the maximum time (in milliseconds) that idle flows will remain cached in the datapath before they are expired. Needed for verification purposes.